### PR TITLE
[codex] Disable temporary ECR publish job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Publishing is temporarily disabled while the registry strategy moves away
+    # from the current AWS ECR path. Keep the safety net live and revisit this
+    # job when the repo is ready to publish to ghcr.io.
+    if: ${{ false }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What changed
This PR temporarily disables the workflow's Docker publish job while leaving the `Pytest safety net` job in place.

## Why it changed
The post-merge `main` workflow is currently failing in the AWS OIDC assume-role step before image publish starts. That is an infrastructure issue separate from the application upgrade itself.

Disabling publish for now keeps the repository's test gate healthy while the team revisits image publishing later as part of a move to `ghcr.io`.

## Impact
- `Pytest safety net` remains active for PRs and `main`
- Docker publish is skipped entirely for now
- AWS ECR/OIDC no longer blocks otherwise healthy merges

## Validation
- workflow logic review only
- no application code paths changed

## Follow-up
- revisit registry publishing in a separate infra slice
- replace the current AWS ECR path with `ghcr.io`
