### PR TITLE
[codex] Fix GHCR smoke check environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,8 +141,24 @@ jobs:
           REGISTRY: ghcr.io
           IMAGE_NAME: onehealthtoolkit/ohtk-api
           IMAGE_TAG: latest
+          DJANGO_SECRET_KEY: django-insecure-ci
+          DJANGO_DEBUG: "False"
+          DJANGO_ALLOWED_HOSTS: 127.0.0.1,localhost
+          USE_INMEMORY_CHANNEL_LAYER: "True"
+          CELERY_TASK_ALWAYS_EAGER: "True"
+          USE_S3: "False"
+          FCM_DRY_RUN: "True"
+          DASHBOARD_URL: http://localhost:3000
         run: |
           docker run --rm --entrypoint python \
+            -e DJANGO_SECRET_KEY \
+            -e DJANGO_DEBUG \
+            -e DJANGO_ALLOWED_HOSTS \
+            -e USE_INMEMORY_CHANNEL_LAYER \
+            -e CELERY_TASK_ALWAYS_EAGER \
+            -e USE_S3 \
+            -e FCM_DRY_RUN \
+            -e DASHBOARD_URL \
             $REGISTRY/$IMAGE_NAME:$IMAGE_TAG \
             manage.py check
 


### PR DESCRIPTION
## What changed
This PR fixes the GHCR publish workflow's image smoke-check step by passing the minimal runtime environment needed for Django to start inside `docker run`.

## Why it changed
PR `#78` switched publishing to GHCR, but the smoke-check container was running `manage.py check` without the expected app environment. That caused Django startup to fail immediately with:

- `django.core.exceptions.ImproperlyConfigured: The SECRET_KEY setting must not be empty.`

## Impact
- keeps the GHCR publish workflow structure from `#78`
- fixes the smoke-check container boot path before image push
- passes CI-style env vars such as `DJANGO_SECRET_KEY`, `DJANGO_DEBUG`, and related test-safe settings into the smoke-check container

## Validation
- workflow logic review
- fix is scoped to `.github/workflows/build.yml`

## Follow-up
- after merge, re-run the GHCR publish workflow and confirm the smoke-check step gets past Django startup
