### PR TITLE
[codex] Add FAO village capability flag

### DIFF
--- a/accounts/schema/mutation.py
+++ b/accounts/schema/mutation.py
@@ -25,6 +25,7 @@ from accounts.schema.mutations import (
     AdminConfigurationCreateMutation,
     AdminConfigurationUpdateMutation,
     AdminConfigurationDeleteMutation,
+    AdminVillageCapabilityUpdateMutation,
     RequestToDeleteMyAccountMutation,
 )
 
@@ -56,4 +57,5 @@ class Mutation(graphene.ObjectType):
     admin_configuration_create = AdminConfigurationCreateMutation.Field()
     admin_configuration_update = AdminConfigurationUpdateMutation.Field()
     admin_configuration_delete = AdminConfigurationDeleteMutation.Field()
+    admin_village_capability_update = AdminVillageCapabilityUpdateMutation.Field()
     request_to_delete_my_account = RequestToDeleteMyAccountMutation.Field()

--- a/accounts/schema/mutations/__init__.py
+++ b/accounts/schema/mutations/__init__.py
@@ -10,4 +10,5 @@ from .verify_login_qr_token_mutation import *
 from .confirm_consent_mutation import *
 from .admin_place_mutations import *
 from .admin_configuration_mutations import *
+from .admin_village_capability_mutations import *
 from .request_to_delete_my_account_mutation import *

--- a/accounts/schema/mutations/admin_village_capability_mutations.py
+++ b/accounts/schema/mutations/admin_village_capability_mutations.py
@@ -1,0 +1,18 @@
+import graphene
+from graphql_jwt.decorators import login_required, superuser_required
+
+from accounts.village_capability import set_village_capability_enabled
+
+
+class AdminVillageCapabilityUpdateMutation(graphene.Mutation):
+    class Arguments:
+        enabled = graphene.Boolean(required=True)
+
+    enabled = graphene.Boolean(required=True)
+
+    @staticmethod
+    @login_required
+    @superuser_required
+    def mutate(root, info, enabled):
+        set_village_capability_enabled(enabled)
+        return AdminVillageCapabilityUpdateMutation(enabled=enabled)

--- a/accounts/schema/query.py
+++ b/accounts/schema/query.py
@@ -35,6 +35,7 @@ from accounts.schema.types import (
 )
 from accounts.schema.types import CheckInvitationCodeType
 from accounts.utils import filter_authority_permission
+from accounts.village_capability import is_village_capability_enabled
 from pagination import DjangoPaginationConnectionField
 
 
@@ -78,6 +79,7 @@ class Query(graphene.ObjectType):
     configuration_get = graphene.Field(
         ConfigurationType, key=graphene.String(required=True)
     )
+    village_capability_enabled = graphene.Boolean(required=True)
 
     get_login_qr_token = graphene.Field(
         LoginQrTokenType, user_id=graphene.ID(required=True)
@@ -244,6 +246,11 @@ class Query(graphene.ObjectType):
     @login_required
     def resolve_configuration_get(root, info, key):
         return Configuration.objects.get(key=key)
+
+    @staticmethod
+    @login_required
+    def resolve_village_capability_enabled(root, info):
+        return is_village_capability_enabled()
 
     @staticmethod
     @login_required

--- a/accounts/tests/test_query_me.py
+++ b/accounts/tests/test_query_me.py
@@ -2,6 +2,9 @@ from django.contrib.auth import get_user_model
 
 from graphql_jwt.testcases import JSONWebTokenTestCase
 
+from accounts.models import Configuration
+from accounts.village_capability import VILLAGE_CAPABILITY_KEY
+
 
 class QueryMeTests(JSONWebTokenTestCase):
     def setUp(self):
@@ -20,3 +23,28 @@ class QueryMeTests(JSONWebTokenTestCase):
         result = self.client.execute(query, {})
         self.assertEqual(self.user.id, result.data["me"]["id"])
         self.assertEqual(self.user.username, result.data["me"]["username"])
+
+    def test_query_me_features_excludes_village_capability_by_default(self):
+        query = """
+        query me {
+            me {
+                features
+            }
+        }
+        """
+        result = self.client.execute(query, {})
+        self.assertIsNone(result.errors, result.errors)
+        self.assertNotIn(VILLAGE_CAPABILITY_KEY, result.data["me"]["features"])
+
+    def test_query_me_features_includes_enabled_village_capability(self):
+        Configuration.objects.create(key=VILLAGE_CAPABILITY_KEY, value="enable")
+        query = """
+        query me {
+            me {
+                features
+            }
+        }
+        """
+        result = self.client.execute(query, {})
+        self.assertIsNone(result.errors, result.errors)
+        self.assertIn(VILLAGE_CAPABILITY_KEY, result.data["me"]["features"])

--- a/accounts/tests/test_village_capability.py
+++ b/accounts/tests/test_village_capability.py
@@ -1,0 +1,80 @@
+from graphql_jwt.testcases import JSONWebTokenTestCase
+
+from accounts.models import Configuration, User
+from accounts.village_capability import (
+    FEATURE_DISABLED_VALUE,
+    FEATURE_ENABLED_VALUE,
+    VILLAGE_CAPABILITY_KEY,
+)
+
+
+class VillageCapabilityTests(JSONWebTokenTestCase):
+    def setUp(self):
+        self.super_user = User.objects.create(username="platform", is_superuser=True)
+        self.user = User.objects.create(username="tenant-admin")
+
+    def execute_query(self):
+        query = """
+        query villageCapabilityEnabled {
+            villageCapabilityEnabled
+        }
+        """
+        return self.client.execute(query, {})
+
+    def execute_update(self, enabled):
+        mutation = """
+        mutation adminVillageCapabilityUpdate($enabled: Boolean!) {
+            adminVillageCapabilityUpdate(enabled: $enabled) {
+                enabled
+            }
+        }
+        """
+        return self.client.execute(mutation, {"enabled": enabled})
+
+    def test_default_missing_configuration_is_disabled(self):
+        self.client.authenticate(self.user)
+        result = self.execute_query()
+        self.assertIsNone(result.errors, result.errors)
+        self.assertFalse(result.data["villageCapabilityEnabled"])
+
+    def test_enabled_configuration_is_enabled(self):
+        Configuration.objects.create(
+            key=VILLAGE_CAPABILITY_KEY, value=FEATURE_ENABLED_VALUE
+        )
+        self.client.authenticate(self.user)
+        result = self.execute_query()
+        self.assertIsNone(result.errors, result.errors)
+        self.assertTrue(result.data["villageCapabilityEnabled"])
+
+    def test_disabled_configuration_is_disabled(self):
+        Configuration.objects.create(
+            key=VILLAGE_CAPABILITY_KEY, value=FEATURE_DISABLED_VALUE
+        )
+        self.client.authenticate(self.user)
+        result = self.execute_query()
+        self.assertIsNone(result.errors, result.errors)
+        self.assertFalse(result.data["villageCapabilityEnabled"])
+
+    def test_superuser_can_update_village_capability(self):
+        self.client.authenticate(self.super_user)
+        result = self.execute_update(True)
+        self.assertIsNone(result.errors, result.errors)
+        self.assertTrue(result.data["adminVillageCapabilityUpdate"]["enabled"])
+
+        configuration = Configuration.objects.get(key=VILLAGE_CAPABILITY_KEY)
+        self.assertEqual(FEATURE_ENABLED_VALUE, configuration.value)
+
+        result = self.execute_update(False)
+        self.assertIsNone(result.errors, result.errors)
+        self.assertFalse(result.data["adminVillageCapabilityUpdate"]["enabled"])
+
+        configuration.refresh_from_db()
+        self.assertEqual(FEATURE_DISABLED_VALUE, configuration.value)
+
+    def test_non_superuser_cannot_update_village_capability(self):
+        self.client.authenticate(self.user)
+        result = self.execute_update(True)
+        self.assertIsNotNone(result.errors)
+        self.assertFalse(
+            Configuration.objects.filter(key=VILLAGE_CAPABILITY_KEY).exists()
+        )

--- a/accounts/tests/test_village_capability.py
+++ b/accounts/tests/test_village_capability.py
@@ -71,6 +71,21 @@ class VillageCapabilityTests(JSONWebTokenTestCase):
         configuration.refresh_from_db()
         self.assertEqual(FEATURE_DISABLED_VALUE, configuration.value)
 
+    def test_superuser_can_restore_soft_deleted_village_capability(self):
+        configuration = Configuration.objects.create(
+            key=VILLAGE_CAPABILITY_KEY, value=FEATURE_DISABLED_VALUE
+        )
+        configuration.delete()
+
+        self.client.authenticate(self.super_user)
+        result = self.execute_update(True)
+        self.assertIsNone(result.errors, result.errors)
+        self.assertTrue(result.data["adminVillageCapabilityUpdate"]["enabled"])
+
+        configuration = Configuration.objects.get(key=VILLAGE_CAPABILITY_KEY)
+        self.assertEqual(FEATURE_ENABLED_VALUE, configuration.value)
+        self.assertIsNone(configuration.deleted_at)
+
     def test_non_superuser_cannot_update_village_capability(self):
         self.client.authenticate(self.user)
         result = self.execute_update(True)

--- a/accounts/village_capability.py
+++ b/accounts/village_capability.py
@@ -1,0 +1,22 @@
+from accounts.models import Configuration
+
+
+VILLAGE_CAPABILITY_KEY = "features.village_enabled"
+FEATURE_ENABLED_VALUE = "enable"
+FEATURE_DISABLED_VALUE = "disable"
+
+
+def is_village_capability_enabled():
+    return Configuration.objects.filter(
+        key=VILLAGE_CAPABILITY_KEY, value=FEATURE_ENABLED_VALUE
+    ).exists()
+
+
+def set_village_capability_enabled(enabled):
+    configuration, _ = Configuration.objects.update_or_create(
+        key=VILLAGE_CAPABILITY_KEY,
+        defaults={
+            "value": FEATURE_ENABLED_VALUE if enabled else FEATURE_DISABLED_VALUE
+        },
+    )
+    return configuration

--- a/accounts/village_capability.py
+++ b/accounts/village_capability.py
@@ -13,10 +13,18 @@ def is_village_capability_enabled():
 
 
 def set_village_capability_enabled(enabled):
-    configuration, _ = Configuration.objects.update_or_create(
+    value = FEATURE_ENABLED_VALUE if enabled else FEATURE_DISABLED_VALUE
+    configuration = Configuration._base_manager.filter(
+        key=VILLAGE_CAPABILITY_KEY
+    ).first()
+    if configuration:
+        configuration.value = value
+        configuration.deleted_at = None
+        configuration.save(update_fields=("value", "deleted_at", "updated_at"))
+        return configuration
+
+    configuration = Configuration.objects.create(
         key=VILLAGE_CAPABILITY_KEY,
-        defaults={
-            "value": FEATURE_ENABLED_VALUE if enabled else FEATURE_DISABLED_VALUE
-        },
+        value=value,
     )
     return configuration


### PR DESCRIPTION
## Summary

Adds the FAO Thin Slice 1A tenant village capability contract to `ohtk-api`.

- stores the tenant gate in existing `accounts.Configuration` as `features.village_enabled`
- adds authenticated GraphQL read field `villageCapabilityEnabled`
- adds superuser/platform-admin-only mutation `adminVillageCapabilityUpdate`
- keeps existing `me.features` behavior, exposing `features.village_enabled` only when enabled

## Impact

This gives later FAO village, invitation, and census slices a backend feature gate without introducing village models, invitation changes, census models, dashboard UI, or mobile UI in this slice.

## Validation

- `pytest accounts/tests/test_village_capability.py accounts/tests/test_query_me.py`
- Result: 8 passed, 2 warnings

## Notes

FAO-feature KB/log files were updated locally in the workspace, but they are outside this child repository and are not part of this PR.