### PR TITLE
[codex] Fix FAO invitation authority update permission

### DIFF
--- a/accounts/schema/mutations/admin_invitation_code_mutations.py
+++ b/accounts/schema/mutations/admin_invitation_code_mutations.py
@@ -205,6 +205,13 @@ class AdminInvitationCodeUpdateMutation(graphene.Mutation):
         target_authority = invitation_code.authority
         if authority_id:
             target_authority = Authority.objects.get(pk=authority_id)
+            if not user.is_superuser:
+                if user.is_authority_role_in([AuthorityUser.Role.ADMIN]):
+                    check_permission_on_inherits_down(user, [target_authority.id])
+                elif user.is_authority_role_in([AuthorityUser.Role.OFFICER]):
+                    check_permission_authority_must_be_the_same(
+                        user, target_authority.id
+                    )
 
         effective_role = role if role is not None else invitation_code.role
         villages = None

--- a/accounts/tests/test_village_reporter_onboarding.py
+++ b/accounts/tests/test_village_reporter_onboarding.py
@@ -71,11 +71,13 @@ class VillageReporterOnboardingTests(JSONWebTokenTestCase):
         mutation adminInvitationCodeUpdate(
             $id: ID!,
             $code: String!,
+            $authorityId: Int,
             $villageIds: [Int]
         ) {
             adminInvitationCodeUpdate(
                 id: $id,
                 code: $code,
+                authorityId: $authorityId,
                 villageIds: $villageIds
             ) {
                 result {
@@ -297,6 +299,37 @@ class VillageReporterOnboardingTests(JSONWebTokenTestCase):
             "invitationCode"
         ]["villages"]
         self.assertEqual([village["code"] for village in villages], ["V002"])
+
+    def test_admin_cannot_update_invitation_to_outside_authority(self):
+        set_village_capability_enabled(True)
+        invitation = InvitationCode.objects.create(
+            code="VIL007",
+            authority=self.authority,
+            role=AuthorityUser.Role.REPORTER,
+        )
+        invitation.villages.set([self.village1])
+        admin = AuthorityUser.objects.create(
+            username="authority-admin",
+            authority=self.authority,
+            role=AuthorityUser.Role.ADMIN,
+        )
+        self.client.authenticate(admin)
+
+        result = self.execute_update_invitation(
+            {
+                "id": invitation.id,
+                "code": "VIL007",
+                "authorityId": self.other_authority.id,
+                "villageIds": [self.other_village.id],
+            }
+        )
+
+        self.assertIsNotNone(result.errors)
+        invitation.refresh_from_db()
+        self.assertEqual(invitation.authority_id, self.authority.id)
+        self.assertEqual(
+            list(invitation.villages.values_list("code", flat=True)), ["V001"]
+        )
 
     def test_query_me_returns_assigned_villages(self):
         set_village_capability_enabled(True)


### PR DESCRIPTION
## Summary
- fix `adminInvitationCodeUpdate` so non-superusers must also have permission on a supplied target `authorityId`
- prevent authority admins/officers from moving an invitation to an out-of-scope authority/village
- add regression coverage for cross-authority invitation update denial

## Root cause
The Slice 1C update mutation checked non-superuser permission against the existing invitation authority, but did not re-check a changed `authorityId` before saving the new authority and village list.

## Validation
- `pytest accounts/tests/test_village_reporter_onboarding.py accounts/tests/test_invitation_code.py accounts/tests/test_admin_invitation_code_crud.py accounts/tests/test_query_me.py` -> 28 passed, 2 warnings
- `python manage.py makemigrations --check --dry-run accounts` -> no changes detected
- `git diff --check` -> clean
- `pytest accounts/tests --ignore=accounts/tests/test_oauth_userinfo.py` -> 89 passed, 2 warnings

## Notes
- Full `pytest accounts/tests` still has the unrelated OAuth `hash_client_secret` failure in `accounts/tests/test_oauth_userinfo.py`.